### PR TITLE
spec-sheet: New 32GB version is released already

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Basic   | Spec Sheet
 CPU     | Quad-core 1.7 GHz ARM® Cortex™ A53 and quad-core 1.0 GHz ARM® Cortex™ A53
 CHIPSET | Qualcomm MSM8939 Snapdragon 615
 GPU     | Adreno 405
-Memory  | 16GB ROM: 2GB RAM.
+Memory  | 16GB/32GB ROM: 2GB RAM.
 Shipped Android Version | 5.0.2
-Storage | 16GB
+Storage | 16GB/32GB
 Battery | 3120 mAh
 Display | 1080 x 1920 pixels, 5.0"  (~441 ppi pixel density)
 Rear Camera  | 13 MP, 4128 x 3096 pixels, autofocus, dual-LED (dual tone) flash


### PR DESCRIPTION
32GB version of Mi4i released a few months ago, updating spec-sheet to reflect it.
